### PR TITLE
Install black on python 3.12 and up

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,7 +10,7 @@ towncrier = "==24.8.0"
 pytest = "==8.3.3"
 pytest-cov = "==5.0.0"
 coverage = "==7.6.1"
-black = "==24.10.0"
+black = {version = "==24.10.0", markers="python_version >= '3.12'"}
 mypy = "==1.11.2"
 tbump = "==6.11.0"
 ruff = "==0.6.9"

--- a/newsfragments/+303487e8.misc.rst
+++ b/newsfragments/+303487e8.misc.rst
@@ -1,0 +1,1 @@
+Updated black installation to not install on python version older than 3.12


### PR DESCRIPTION
Chore that needs to be done:

* [ ] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number