### PR TITLE
Support Python 3.13, drop support for Python 3.8

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: fizyk/actions-reuse/.github/actions/pipenv@v2.4.8
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           command: tbump --dry-run --only-patch $(pipenv run tbump current-version)"-x"
   towncrier:
     runs-on: ubuntu-latest
@@ -20,6 +20,6 @@ jobs:
     steps:
       - uses: fizyk/actions-reuse/.github/actions/pipenv@v2.4.8
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           command: towncrier check --compare-with origin/master
           fetch-depth: 0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,11 +10,11 @@ jobs:
   tests:
     uses: fizyk/actions-reuse/.github/workflows/tests-pytests.yml@v2.4.8
     with:
-      python-versions: '["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.8"]'
+      python-versions: '["3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.10"]'
   tests-macos:
     needs:
       - tests
     uses: fizyk/actions-reuse/.github/workflows/tests-pytests.yml@v2.4.8
     with:
-      python-versions: '["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.8"]'
+      python-versions: '["3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.10"]'
       os: macos-latest

--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,8 @@ port-for
    :target: https://pypi.python.org/pypi/port-for
    :alt: PyPI Version
 
-.. image:: http://codecov.io/github/kmike/port-for/coverage.svg?branch=master
-   :target: http://codecov.io/github/kmike/port-for?branch=master
+.. image:: http://codecov.io/github/fizyk/port-for/coverage.svg?branch=master
+   :target: http://codecov.io/github/fizyk/port-for?branch=master
    :alt: Code Coverage
 
 

--- a/newsfragments/+13d35d54.feature.rst
+++ b/newsfragments/+13d35d54.feature.rst
@@ -1,0 +1,1 @@
+Added Python 3.13 to the supported Python Versions

--- a/newsfragments/+367bc0ff.break.rst
+++ b/newsfragments/+367bc0ff.break.rst
@@ -1,0 +1,1 @@
+Dropped support for Python 3.8 (it has reached EOL)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,12 +23,13 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Operating System :: POSIX",
     "Topic :: System :: Installation/Setup",
     "Topic :: System :: Systems Administration",
     "Topic :: Internet :: WWW/HTTP :: Site Management",
 ]
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 
 [project.urls]
 "Source" = "https://github.com/kmike/port-for/"
@@ -87,7 +88,7 @@ showcontent = false
 
 [tool.black]
 line-length = 80
-target-version = ['py38']
+target-version = ['py39']
 include = '.*\.pyi?$'
 
 [tool.ruff]


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number