### PR TITLE
Fix test_port_mix again

### DIFF
--- a/newsfragments/+3b5c4387.misc.rst
+++ b/newsfragments/+3b5c4387.misc.rst
@@ -1,0 +1,1 @@
+Fix test_port_mix again.

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -112,11 +112,12 @@ def test_port_mix() -> None:
         (2000, 3000),
         {4001, 4002, 4003},
     ]
-    assert get_port(sets_and_ranges) in set(range(2000, 3000 + 1)) and {
+    want_set = set(range(2000, 3000 + 1)) | {
         4001,
         4002,
         4003,
     }
+    assert get_port(sets_and_ranges) in want_set
 
 
 class SelectPortTest(unittest.TestCase):


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number
