### PR TITLE
Add flake8-boolean-trap (FBT) to the ruff lint ruleset - closes #461

### DIFF
--- a/newsfragments/461.misc.rst
+++ b/newsfragments/461.misc.rst
@@ -1,0 +1,1 @@
+Add flake8-boolean-trap (FBT) to the ruff lint ruleset.

--- a/port_for/api.py
+++ b/port_for/api.py
@@ -139,7 +139,7 @@ def _accepts_connection(port: int, host: str) -> bool:
     """
     with socket.socket() as sock:
         sock.settimeout(1)
-        sock.setblocking(True)
+        sock.setblocking(True)  # noqa: FBT003 - C function, no kwargs allowed
         err = sock.connect_ex((host, port))
         # Relying on ECONNREFUSED does not produce reliable results on windows,
         # which could result in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,10 +71,11 @@ line-length = 100
 
 [tool.ruff.lint]
 select = [
-    "E", # pycodestyle
-    "F", # pyflakes
-    "I", # isort
-    "D", # pydocstyle
+    "E",   # pycodestyle
+    "F",   # pyflakes
+    "I",   # isort
+    "D",   # pydocstyle
+    "FBT", # flake8-boolean-trap
 ]
 exclude = [ "port_for/_download_ranges.py" ]
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled additional linting checks for boolean arguments.
  * Updated code annotations to comply with the new checks.
* **Documentation**
  * Added a news fragment documenting the linting update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->